### PR TITLE
DEV-89 handle 403 unauthorized download

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="gdc-maf-tool",
-    version="0.0.1",
+    version="0.0.2",
     description="GDC MAF Tool",
     license="Apache",
     packages=find_packages(),

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,0 +1,11 @@
+from httmock import urlmatch
+
+VALID_TOKEN = "valid-token"  # nosec
+INVAVLID_TOKEN = "bad-token"  # nosec
+
+
+@urlmatch(path=".*/data/(.*)$")
+def download_mock(url, request):
+    if request.headers.get("X-Auth-Token", "") == VALID_TOKEN:
+        return {"status_code": 200, "content": "test content"}
+    return {"status_code": 403, "content": "failed request"}

--- a/tests/test_gdc_api_clilent.py
+++ b/tests/test_gdc_api_clilent.py
@@ -1,0 +1,20 @@
+import pytest
+from httmock import HTTMock
+from tests import mocks
+
+from gdc_maf_tool import gdc_api_client
+
+
+@pytest.mark.parametrize(
+    "uuid, token, expected_result",
+    [
+        ("one", mocks.VALID_TOKEN, True),
+        ("two", None, False),
+        ("three", mocks.INVAVLID_TOKEN, False),
+    ],
+)
+def test_can_download_maf(uuid, token, expected_result):
+    with HTTMock(mocks.download_mock):
+        can_download = gdc_api_client.can_download_maf(uuid, token)
+
+    assert can_download == expected_result

--- a/tests/test_gdc_maf_client.py
+++ b/tests/test_gdc_maf_client.py
@@ -1,4 +1,11 @@
-from gdc_maf_tool.gdc_api_client import _select_mafs, _build_hit_map, _parse_hit
+from httmock import HTTMock
+from tests import mocks
+
+from gdc_maf_tool.gdc_api_client import (
+    _build_hit_map,
+    _parse_hit,
+    _select_mafs,
+)
 
 
 def test__select_mafs():
@@ -116,7 +123,9 @@ def test__select_mafs():
             },
         },
     }
-    mafs = _select_mafs(
-        _build_hit_map([_parse_hit(hit) for hit in results["data"]["hits"]]), None
-    )
+    with HTTMock(mocks.download_mock):
+        mafs = _select_mafs(
+            _build_hit_map([_parse_hit(hit) for hit in results["data"]["hits"]]),
+            mocks.VALID_TOKEN,
+        )
     assert mafs[0].tumor_aliquot_submitter_id == "TARGET-20-PANLRE-09A-01D"


### PR DESCRIPTION
Handle the case where a user tries to download data they don't have access to. Skip the file and continue execution.