### PR TITLE
(chore): Use https for editable github dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,25 @@
 Installing
 ---
 
-Requires Python 3.6 or later
+Requires Git and Python 3.6 or later.
 
+#### Clone the repo:
 ```shell
-$ virtualenv venv
+$ git clone https://github.com/NCI-GDC/gdc-maf-tool.git
+```
+#### Create a virtualenv:
+For Linux and Macos:
+```shell
+$ python3 -m venv venv
 $ source venv/bin/activate
+```
+For windows:
+```shell
+$ py -m venv venv
+$ .\venv\Scripts\activate
+```
+#### Install the tool in the virtualenv:
+```shell
 $ pip install -r requirements.txt
 $ python setup.py install
 ```
@@ -66,7 +80,7 @@ $ tox
 Contributing
 ---
 
-We use `pre-commit` to enforce formatting and linting.  It needs to be installed 
+We use `pre-commit` to enforce formatting and linting.  It needs to be installed
 in your local copy of this repo.
 
 ```shell script

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
 requests>=2.22.0,<3
 
--e git+ssh://git@github.com/uc-cdis/cdislogging.git@0.0.2#egg=cdislogging
--e git+ssh://git@github.com/NCI-GDC/aliquot-level-maf.git@0.2.0#egg=aliquot_level_maf
+-e git+https://github.com/uc-cdis/cdislogging.git@0.0.2#egg=cdislogging
+-e git+https://github.com/NCI-GDC/aliquot-level-maf.git@0.2.0#egg=aliquot_level_maf

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@
 #
 #    pip-compile requirements.in
 #
--e git+ssh://git@github.com/NCI-GDC/aliquot-level-maf.git@0.2.0#egg=aliquot_level_maf  # via -r requirements.in
--e git+ssh://git@github.com/uc-cdis/cdislogging.git@0.0.2#egg=cdislogging  # via -r requirements.in
+-e git+https://github.com/NCI-GDC/aliquot-level-maf.git@0.2.0#egg=aliquot_level_maf  # via -r requirements.in
+-e git+https://github.com/uc-cdis/cdislogging.git@0.0.2#egg=cdislogging  # via -r requirements.in
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
 idna==2.8                 # via requests


### PR DESCRIPTION
* Setting up ssh is difficult on windows. Using https allows easier
installation of open source github dependencies.