### PR TITLE
Add main call so pyinstaller can pick it up

### DIFF
--- a/gdc_maf_tool/cli.py
+++ b/gdc_maf_tool/cli.py
@@ -99,3 +99,7 @@ def main() -> None:
         logger.info("Successfully downloaded %s files", len(mafs) - len(failed))
         if failed:
             logger.info("Failed to download %s files", len(failed))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
If it's main isn't called by any of the modules then it won't get called by pyinstaller.