### PR TITLE
Feat/dev 149 disable aliquot selection

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-05-07T20:17:19Z",
+  "generated_at": "2020-08-24T16:26:24Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -60,14 +60,14 @@
         "hashed_secret": "b1731f490e23e0f871edf3de36d57030d6d5d51f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 63,
+        "line_number": 61,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "855633c7a6f35e68a38a398aaafd39085f9d0428",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 112,
+        "line_number": 110,
         "type": "Hex High Entropy String"
       }
     ]

--- a/gdc_maf_tool/cli.py
+++ b/gdc_maf_tool/cli.py
@@ -41,7 +41,16 @@ def parse_args() -> argparse.Namespace:
         "--output",
         dest="output_filename",
         default="outfile.maf.gz",
-        help="Output file name for the resulting aggregate MAF (default: outfile.maf.gz).",
+        help=(
+            "Output file name for the resulting aggregate MAF (default:"
+            " outfile.maf.gz)."
+        ),
+    )
+    parser.add_argument(
+        "-d",
+        "--disable-aliquot-selection",
+        action="store_true",
+        help="Disable primary aliquot selection logic",
     )
     return parser.parse_args()
 
@@ -76,7 +85,9 @@ def main() -> None:
     elif args.file_manifest:
         file_ids = ids_from_manifest(args.file_manifest)
 
-    mafs = gdc_api_client.collect_mafs(args.project_id, case_ids, file_ids, token)
+    mafs = gdc_api_client.collect_mafs(
+        args.project_id, args.disable_aliquot_selection, case_ids, file_ids, token
+    )
 
     with open(args.output_filename, "wb") as f:
         aggregate_mafs(mafs, f)

--- a/gdc_maf_tool/cli.py
+++ b/gdc_maf_tool/cli.py
@@ -47,10 +47,13 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
-        "-d",
-        "--disable-aliquot-selection",
+        "-a",
+        "--all-files",
         action="store_true",
-        help="Disable primary aliquot selection logic",
+        help=(
+            "Include all aliquot-level MAF files. Will perform primary aliquot"
+            " selection per file"
+        ),
     )
     return parser.parse_args()
 
@@ -86,7 +89,7 @@ def main() -> None:
         file_ids = ids_from_manifest(args.file_manifest)
 
     mafs = gdc_api_client.collect_mafs(
-        args.project_id, args.disable_aliquot_selection, case_ids, file_ids, token
+        args.project_id, args.all_files, case_ids, file_ids, token
     )
 
     with open(args.output_filename, "wb") as f:

--- a/gdc_maf_tool/defer.py
+++ b/gdc_maf_tool/defer.py
@@ -41,17 +41,17 @@ class DeferredRequestReader(io.BufferedIOBase):
 
         response = self._provider()
         if response.status_code == 403:
-            logger.warn("[403] Unable to downoad %s. Skipping...", self.uuid)
+            logger.warning("[403] Unable to downoad %s. Skipping...", self.uuid)
             self.failed_reason = "Not authorized"
             return
 
         if response.status_code == 404:
-            logger.warn("[404] File not found %s. Skipping...", self.uuid)
+            logger.warning("[404] File not found %s. Skipping...", self.uuid)
             self.failed_reason = "File not found"
             return
 
         if response.status_code != 200:
-            logger.warn(
+            logger.warning(
                 "[%s] Uncaught error %s. Skipping...", response.status_code, self.uuid
             )
             self.failed_reason = "Uncaught error code: {}".format(response.status_code)

--- a/gdc_maf_tool/gdc_api_client.py
+++ b/gdc_maf_tool/gdc_api_client.py
@@ -188,7 +188,7 @@ def collect_criteria(
 
 def collect_mafs(
     project_id: str,
-    disable_aliquot_selection: bool,
+    include_all_files: bool,
     case_ids: List[str],
     file_ids: List[str],
     token: Optional[str],
@@ -215,7 +215,7 @@ def collect_mafs(
     if file_ids:
         check_for_missing_ids(hit_map, file_ids, "file_id")
 
-    return _select_mafs(hit_map, token, disable_aliquot_selection)
+    return _select_mafs(hit_map, token, include_all_files)
 
 
 def check_for_missing_ids(
@@ -249,13 +249,13 @@ def _build_hit_map(hits):
     return {h["file_id"]: h for h in hits}
 
 
-def _select_mafs(hit_map, token, disable_aliquot_selection):
+def _select_mafs(hit_map, token, include_all_files):
     mafs = []
     only_one_project_id(hit_map)
 
-    # if disable_aliquot_selection is set, perfrorm primary aliquot selection per file
+    # if include_all_files is set, perfrorm primary aliquot selection per file
     # else perform primary aliquot selection per case
-    entity = "file_id" if disable_aliquot_selection else "case_id"
+    entity = "file_id" if include_all_files else "case_id"
     criteria = collect_criteria(hit_map, entity)
     selections = select_primary_aliquots(criteria)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile setup.py
 #
-git+https://github.com/NCI-GDC/aliquot-level-maf.git@0.2.1  # via gdc-maf-tool (setup.py)
+git+https://github.com/NCI-GDC/aliquot-level-maf.git@0.2.2  # via gdc-maf-tool (setup.py)
 git+https://github.com/uc-cdis/cdislogging.git@0.0.2  # via gdc-maf-tool (setup.py)
 certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,6 @@ setup(
         "requests>=2.22.0,<3",
         "defusedcsv>=1.0.0,<2.0.0",
         "cdislogging@git+https://github.com/uc-cdis/cdislogging.git@0.0.2",
-        "aliquot_level_maf@git+https://github.com/NCI-GDC/aliquot-level-maf.git@0.2.1",
+        "aliquot_level_maf@git+https://github.com/NCI-GDC/aliquot-level-maf.git@0.2.2",
     ],
 )

--- a/tests/test_gdc_maf_client.py
+++ b/tests/test_gdc_maf_client.py
@@ -7,125 +7,140 @@ from gdc_maf_tool.gdc_api_client import (
     _select_mafs,
 )
 
+results = {
+    "warnings": {},
+    "data": {
+        "hits": [
+            {
+                "cases": [
+                    {
+                        "project": {"project_id": "TARGET-AML"},
+                        "case_id": "06cd1d5f-9918-5db2-8c0d-3a0cedea5748",
+                        "samples": [
+                            {
+                                "tissue_type": "Not Reported",
+                                "portions": [
+                                    {
+                                        "analytes": [
+                                            {
+                                                "aliquots": [
+                                                    {
+                                                        "submitter_id": "TARGET-20-PANLRE-09A-01D"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "sample_type": "Primary Blood Derived Cancer - Bone Marrow",
+                            },
+                            {
+                                "tissue_type": "Not Reported",
+                                "portions": [
+                                    {
+                                        "analytes": [
+                                            {
+                                                "aliquots": [
+                                                    {
+                                                        "submitter_id": "TARGET-20-PANLRE-14A-01E"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "sample_type": "Bone Marrow Normal",
+                            },
+                        ],
+                    }
+                ],
+                "file_id": "080765f4-349d-4646-954c-9673fa2033e6",
+                "id": "080765f4-349d-4646-954c-9673fa2033e6",
+                "created_datetime": "2020-03-17T21:24:16.127588-05:00",
+                "file_size": 4771,
+                "md5sum": "192320bb88982621512869f50add3a20",
+            },
+            {
+                "cases": [
+                    {
+                        "project": {"project_id": "TARGET-AML"},
+                        "case_id": "06cd1d5f-9918-5db2-8c0d-3a0cedea5748",
+                        "samples": [
+                            {
+                                "tissue_type": "Not Reported",
+                                "portions": [
+                                    {
+                                        "analytes": [
+                                            {
+                                                "aliquots": [
+                                                    {
+                                                        "submitter_id": "TARGET-20-PANLRE-04A-01F"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "sample_type": "Recurrent Blood Derived Cancer - Bone Marrow",
+                            },
+                            {
+                                "tissue_type": "Not Reported",
+                                "portions": [
+                                    {
+                                        "analytes": [
+                                            {
+                                                "aliquots": [
+                                                    {
+                                                        "submitter_id": "TARGET-20-PANLRE-14A-01G"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "sample_type": "Bone Marrow Normal",
+                            },
+                        ],
+                    }
+                ],
+                "file_id": "3609f3b5-3827-4114-9529-e3e8e1998902",
+                "id": "3609f3b5-3827-4114-9529-e3e8e1998902",
+                "created_datetime": "2020-03-17T21:24:16.127588-05:00",
+                "file_size": 1050,
+                "md5sum": "50fafde798b8d533135a35d417ad164e",
+            },
+        ],
+        "pagination": {
+            "total": 2,
+            "page": 1,
+            "count": 2,
+            "sort": "",
+            "from": 0,
+            "size": 5000,
+            "pages": 1,
+        },
+    },
+}
+
 
 def test__select_mafs():
-    results = {
-        "warnings": {},
-        "data": {
-            "hits": [
-                {
-                    "cases": [
-                        {
-                            "project": {"project_id": "TARGET-AML"},
-                            "case_id": "06cd1d5f-9918-5db2-8c0d-3a0cedea5748",
-                            "samples": [
-                                {
-                                    "tissue_type": "Not Reported",
-                                    "portions": [
-                                        {
-                                            "analytes": [
-                                                {
-                                                    "aliquots": [
-                                                        {
-                                                            "submitter_id": "TARGET-20-PANLRE-09A-01D"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "sample_type": "Primary Blood Derived Cancer - Bone Marrow",
-                                },
-                                {
-                                    "tissue_type": "Not Reported",
-                                    "portions": [
-                                        {
-                                            "analytes": [
-                                                {
-                                                    "aliquots": [
-                                                        {
-                                                            "submitter_id": "TARGET-20-PANLRE-14A-01D"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "sample_type": "Bone Marrow Normal",
-                                },
-                            ],
-                        }
-                    ],
-                    "file_id": "080765f4-349d-4646-954c-9673fa2033e6",
-                    "id": "080765f4-349d-4646-954c-9673fa2033e6",
-                    "created_datetime": "2020-03-17T21:24:16.127588-05:00",
-                    "file_size": 4771,
-                    "md5sum": "192320bb88982621512869f50add3a20",
-                },
-                {
-                    "cases": [
-                        {
-                            "project": {"project_id": "TARGET-AML"},
-                            "case_id": "06cd1d5f-9918-5db2-8c0d-3a0cedea5748",
-                            "samples": [
-                                {
-                                    "tissue_type": "Not Reported",
-                                    "portions": [
-                                        {
-                                            "analytes": [
-                                                {
-                                                    "aliquots": [
-                                                        {
-                                                            "submitter_id": "TARGET-20-PANLRE-04A-01D"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "sample_type": "Recurrent Blood Derived Cancer - Bone Marrow",
-                                },
-                                {
-                                    "tissue_type": "Not Reported",
-                                    "portions": [
-                                        {
-                                            "analytes": [
-                                                {
-                                                    "aliquots": [
-                                                        {
-                                                            "submitter_id": "TARGET-20-PANLRE-14A-01D"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "sample_type": "Bone Marrow Normal",
-                                },
-                            ],
-                        }
-                    ],
-                    "file_id": "3609f3b5-3827-4114-9529-e3e8e1998902",
-                    "id": "3609f3b5-3827-4114-9529-e3e8e1998902",
-                    "created_datetime": "2020-03-17T21:24:16.127588-05:00",
-                    "file_size": 1050,
-                    "md5sum": "50fafde798b8d533135a35d417ad164e",
-                },
-            ],
-            "pagination": {
-                "total": 2,
-                "page": 1,
-                "count": 2,
-                "sort": "",
-                "from": 0,
-                "size": 5000,
-                "pages": 1,
-            },
-        },
-    }
     with HTTMock(mocks.download_mock):
         mafs = _select_mafs(
             _build_hit_map([_parse_hit(hit) for hit in results["data"]["hits"]]),
             mocks.VALID_TOKEN,
+            False,
         )
+    assert len(mafs) == 1
     assert mafs[0].tumor_aliquot_submitter_id == "TARGET-20-PANLRE-09A-01D"
+
+
+def test__select_mafs_disable_primary_aliquot():
+    with HTTMock(mocks.download_mock):
+        mafs = _select_mafs(
+            _build_hit_map([_parse_hit(hit) for hit in results["data"]["hits"]]),
+            mocks.VALID_TOKEN,
+            True,
+        )
+    assert len(mafs) == 2
+    assert mafs[0].tumor_aliquot_submitter_id == "TARGET-20-PANLRE-09A-01D"
+    assert mafs[1].tumor_aliquot_submitter_id == "TARGET-20-PANLRE-04A-01F"

--- a/tests/test_gdc_maf_client.py
+++ b/tests/test_gdc_maf_client.py
@@ -123,7 +123,7 @@ results = {
 }
 
 
-def test__select_mafs():
+def test__select_mafs_per_case():
     with HTTMock(mocks.download_mock):
         mafs = _select_mafs(
             _build_hit_map([_parse_hit(hit) for hit in results["data"]["hits"]]),
@@ -134,7 +134,7 @@ def test__select_mafs():
     assert mafs[0].tumor_aliquot_submitter_id == "TARGET-20-PANLRE-09A-01D"
 
 
-def test__select_mafs_disable_primary_aliquot():
+def test__select_mafs_per_file():
     with HTTMock(mocks.download_mock):
         mafs = _select_mafs(
             _build_hit_map([_parse_hit(hit) for hit in results["data"]["hits"]]),


### PR DESCRIPTION
Adding an option to disable primary aliquot selection, which will allow users to get all aliquot-level MAF files. Primary aliquot selection still needs to be done per file, so this change will allow for that:
[https://github.com/NCI-GDC/aliquot-level-maf/pull/6
](https://github.com/NCI-GDC/aliquot-level-maf/pull/6
)

I added a test case for this. I was getting warnings for logger.warn() being deprecated in the defer.py file, so I upgraded it to the most up to date logger.warning()